### PR TITLE
Fix dialogue crashes

### DIFF
--- a/DCF/Mods/DCF/meta.lsx
+++ b/DCF/Mods/DCF/meta.lsx
@@ -21,7 +21,7 @@
                     <attribute id="Tags" type="LSString" value=""/>
                     <attribute id="Type" type="FixedString" value="Add-on"/>
                     <attribute id="UUID" type="FixedString" value="cbf23bc3-e48e-464a-a1c1-cefc773d3225"/>
-                    <attribute id="Version64" type="int64" value="36028797018963968"/>
+                    <attribute id="Version64" type="int64" value="36169534507319296"/>
                     <children>
                         <node id="PublishVersion">
                             <attribute id="Version64" type="int64" value="36028797018963968"/>

--- a/DCF/Public/DCF/Stats/Generated/Data/DisableCritFail.txt
+++ b/DCF/Public/DCF/Stats/Generated/Data/DisableCritFail.txt
@@ -1,7 +1,7 @@
 new entry "RAW_DisableSkillCheckCritFail"
 type "PassiveData"
 data "Properties" "IsHidden"
-data "Boosts" "MinimumRollResult(RawAbility,2);MinimumRollResult(SkillCheck,2)"
+data "Boosts" "IF(RAW_IsSkillCheck(context.Source)):MinimumRollResult(SkillCheck,2);IF(RAW_IsAbilityCheck(context.Source)):MinimumRollResult(RawAbility,2)"
 
 new entry "_Hero"
 type "Character"

--- a/DCF/Scripts/thoth/helpers/DCF.khn
+++ b/DCF/Scripts/thoth/helpers/DCF.khn
@@ -1,0 +1,35 @@
+function RAW_IsAbilityCheck(entity)
+    local entity = entity or context.Source
+    local isStr = context.CheckedAbility == Ability.Strength
+    local isDex = context.CheckedAbility == Ability.Dexterity
+    local isCon = context.CheckedAbility == Ability.Constitution
+    local isInt = context.CheckedAbility == Ability.Intelligence
+    local isWis = context.CheckedAbility == Ability.Wisdom
+    local isCha = context.CheckedAbility == Ability.Charisma
+    return ConditionResult(isStr or isDex or isCon or isInt or isWis or isCha)
+end
+
+function RAW_IsSkillCheck(entity)
+    local entity = entity or context.Source
+    local isAthletics = context.CheckedSkill == Skill.Athletics
+    local isAcrobatics = context.CheckedSkill == Skill.Acrobatics
+    local isSleightOfHand = context.CheckedSkill == Skill.SleightOfHand
+    local isStealth = context.CheckedSkill == Skill.Stealth
+    local isArcana = context.CheckedSkill == Skill.Arcana
+    local isHistory = context.CheckedSkill == Skill.History
+    local isInvestigation = context.CheckedSkill == Skill.Investigation
+    local isNature = context.CheckedSkill == Skill.Nature
+    local isReligion = context.CheckedSkill == Skill.Religion
+    local isAnimalHandling = context.CheckedSkill == Skill.AnimalHandling
+    local isInsight = context.CheckedSkill == Skill.Insight
+    local isMedicine = context.CheckedSkill == Skill.Medicine
+    local isPerception = context.CheckedSkill == Skill.Perception
+    local isSurvival = context.CheckedSkill == Skill.Survival
+    local isDeception = context.CheckedSkill == Skill.Deception
+    local isIntimidation = context.CheckedSkill == Skill.Intimidation
+    local isPerformance = context.CheckedSkill == Skill.Performance
+    local isPersuasion = context.CheckedSkill == Skill.Persuasion
+    return ConditionResult(isAthletics or isAcrobatics or isSleightOfHand or isStealth or isArcana or isHistory or isInvestigation or
+        isNature or isReligion or isAnimalHandling or isInsight or isMedicine or isPerception or isSurvival or isDeception or
+        isIntimidation or isPerformance or isPersuasion)
+end


### PR DESCRIPTION
- Some dialogues run obscure dice rolls on the background, causing crashes if the `MinimumRollResult()` is applied to then. Fixes that by only providing the adjusted roll to specific ability and skill checks (all of the 5e checks, but none of the legacy stuff present in abilities or skills from DOS2)